### PR TITLE
Avoid unnecessary query

### DIFF
--- a/src/QueryBuilder/ModelLoader.php
+++ b/src/QueryBuilder/ModelLoader.php
@@ -123,12 +123,14 @@ class ModelLoader
      */
     public function loadCount($countable): self
     {
-        $counter = new CountableLoader(
-            $this->schema,
-            CountablePaths::cast($countable)
-        );
+        if ($countable) {
+            $counter = new CountableLoader(
+                $this->schema,
+                CountablePaths::cast($countable)
+            );
 
-        $this->target->loadCount($counter->getRelations());
+            $this->target->loadCount($counter->getRelations());
+        }
 
         return $this;
     }


### PR DESCRIPTION
For queries to a single resource (e.g. `v1/pages/1` )for which no relations should be fetched, there's an unnecessary query executed:

```
select "id" from "pages" where "pages"."id" in (1)
```

This is because `$this->queryParameters->countable()` returns `NULL` here:
https://github.com/laravel-json-api/eloquent/blob/develop/src/QueryOne.php#L125

The patch checks avoids that query if it's not necessary.